### PR TITLE
Supports parametrizing the Dexie query with a source function (i.e. a signal)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "vite-plugin-solid": "^2.2.6"
       },
       "peerDependencies": {
-        "dexie": "^4.0.0-alpha.4",
+        "dexie": "^3.2.2 || ^4.0.0-alpha.4",
         "solid-js": "^1.4.6"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "vite-plugin-solid": "^2.2.6"
       },
       "peerDependencies": {
-        "dexie": "^3.2.2",
+        "dexie": "^4.0.0-alpha.4",
         "solid-js": "^1.4.6"
       }
     },
@@ -3578,9 +3578,9 @@
       }
     },
     "node_modules/dexie": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.2.tgz",
-      "integrity": "sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg==",
+      "version": "4.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.0.0-alpha.4.tgz",
+      "integrity": "sha512-xYABeT5ctG7WAJtyr/6gKhWXD6NY8ydZieQlvLQkFV6KXY33I+ShE39pToGzQw+3/xs760rW+opxhoVZ/yzVxQ==",
       "peer": true,
       "engines": {
         "node": ">=6.0"
@@ -12041,9 +12041,9 @@
       "dev": true
     },
     "dexie": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.2.tgz",
-      "integrity": "sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg==",
+      "version": "4.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.0.0-alpha.4.tgz",
+      "integrity": "sha512-xYABeT5ctG7WAJtyr/6gKhWXD6NY8ydZieQlvLQkFV6KXY33I+ShE39pToGzQw+3/xs760rW+opxhoVZ/yzVxQ==",
       "peer": true
     },
     "diff-sequences": {

--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
     "solid-jest": "^0.2.0",
     "typescript": "^4.6.4",
     "version-changelog": "^3.1.1",
-    "vite": "^2.9.8",
+    "vite": "^2.9.9",
     "vite-plugin-solid": "^2.2.6"
   },
   "peerDependencies": {
-    "dexie": "^3.2.2",
+    "dexie": "^4.0.0-alpha.4",
     "solid-js": "^1.4.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "solid-jest": "^0.2.0",
     "typescript": "^4.6.4",
     "version-changelog": "^3.1.1",
-    "vite": "^2.9.9",
+    "vite": "^2.9.8",
     "vite-plugin-solid": "^2.2.6"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vite-plugin-solid": "^2.2.6"
   },
   "peerDependencies": {
-    "dexie": "^4.0.0-alpha.4",
+    "dexie": "^3.2.2 || ^4.0.0-alpha.4",
     "solid-js": "^1.4.6"
   }
 }

--- a/src/from-reconcile-store.ts
+++ b/src/from-reconcile-store.ts
@@ -1,0 +1,19 @@
+import { onCleanup } from "solid-js";
+import { reconcile, ReconcileOptions, SetStoreFunction } from "solid-js/store";
+
+export const DEFAULT_RECONCILE_OPTIONS: ReconcileOptions = { key: "id" }
+
+export const fromReconcileStore = <T>(
+  producer: {
+    subscribe: (
+      fn: (v: T) => void
+    ) => (() => void) | { unsubscribe: () => void };
+  },
+  store: T,
+  setStore: SetStoreFunction<T>,
+  options: ReconcileOptions = DEFAULT_RECONCILE_OPTIONS
+): T => {
+  const unsub = producer.subscribe((v) => setStore(reconcile(v, options)));
+  onCleanup(() => ("unsubscribe" in unsub ? unsub.unsubscribe() : unsub()));
+  return store;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { createDexieSignalQuery, createDexieArrayQuery, createDexieArrayQueryWithSource } from "./solid-dexie";
+export { createDexieSignalQuery, createDexieArrayQuery } from "./solid-dexie";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { createDexieSignalQuery, createDexieArrayQuery } from "./solid-dexie";
+export { createDexieSignalQuery, createDexieArrayQuery, createDexieArrayQueryWithSource } from "./solid-dexie";

--- a/src/solid-dexie.test.ts
+++ b/src/solid-dexie.test.ts
@@ -128,45 +128,9 @@ describe("createDexieArrayQuery", () => {
       await db.friends.add({ name: "Foo", age: 10 });
     });
     expect(friends!).toMatchObject([{ name: "Foo", age: 10 }]);
-  });
+  });;
 
-  test("filtered live array (1), add one item", async () => {
-    let friends: Friend[];
-
-    const [resolve, startup, runDb] = runner();
-
-    const PARAM = 30;
-
-    await createRoot(async () => {
-      const matchingFriends = createDexieArrayQuery((source) => {
-        return db.friends.where({ age: source }).toArray();
-      }, {
-        source: PARAM
-      });
-
-      createEffect(
-        on(
-          () => [matchingFriends.length],
-          () => {
-            friends = matchingFriends;
-            resolve();
-          }
-        )
-      );
-    });
-
-    await startup();
-    expect(friends!).toEqual([]);
-
-    await runDb(async () => {
-      await db.friends.add({ name: "Foo", age: 20 });
-      await db.friends.add({ name: "Expected", age: PARAM });
-      await db.friends.add({ name: "Foo", age: 40 });
-    });
-    expect(friends!).toMatchObject([{ name: "Expected", age: PARAM }]);
-  });
-
-  test("filtered live array (2), add two items", async () => {
+  test("filtered live array, add items, signal as parameter", async () => {
     let friends: Friend[];
 
     const [resolve, startup, runDb] = runner();

--- a/src/solid-dexie.test.ts
+++ b/src/solid-dexie.test.ts
@@ -138,9 +138,9 @@ describe("createDexieArrayQuery", () => {
     const PARAM = 30;
 
     await createRoot(async () => {
-      const matchingFriends = createDexieArrayQueryWithSource(() => {
-        return db.friends.where({ age: 30 }).toArray();
-      }, 30);
+      const matchingFriends = createDexieArrayQueryWithSource((source) => {
+        return db.friends.where({ age: source() }).toArray();
+      }, PARAM);
 
       createEffect(
         on(

--- a/src/solid-dexie.test.ts
+++ b/src/solid-dexie.test.ts
@@ -2,7 +2,7 @@ import "fake-indexeddb/auto";
 import { createRoot, on, createEffect, createSignal, Setter, createRenderEffect } from "solid-js";
 
 import { DbFixture, Friend } from "./db-fixture";
-import { createDexieSignalQuery, createDexieArrayQuery, createDexieArrayQueryWithSource } from "./solid-dexie";
+import { createDexieSignalQuery, createDexieArrayQuery } from "./solid-dexie";
 
 let db: DbFixture;
 
@@ -138,9 +138,11 @@ describe("createDexieArrayQuery", () => {
     const PARAM = 30;
 
     await createRoot(async () => {
-      const matchingFriends = createDexieArrayQueryWithSource((source) => {
+      const matchingFriends = createDexieArrayQuery((source) => {
         return db.friends.where({ age: source }).toArray();
-      }, PARAM);
+      }, {
+        source: PARAM
+      });
 
       createEffect(
         on(
@@ -173,9 +175,11 @@ describe("createDexieArrayQuery", () => {
 
     await createRoot(async () => {
       const [filter, setFilter] = createSignal(35);
-      const matchingFriends = createDexieArrayQueryWithSource((x) => {
+      const matchingFriends = createDexieArrayQuery((x) => {
         return db.friends.where({ age: x }).toArray();
-      }, filter);
+      }, {
+        source: filter
+      });
 
       createRenderEffect(() => {
         setFilter(PARAM);

--- a/src/solid-dexie.test.ts
+++ b/src/solid-dexie.test.ts
@@ -169,11 +169,10 @@ describe("createDexieArrayQuery", () => {
 
     const [resolve, startup, runDb] = runner();
 
-    const DEFAULT = 50;
     const PARAM = 30;
 
     await createRoot(async () => {
-      const [param, setParam] = createSignal(DEFAULT);
+      const [param, setParam] = createSignal(35);
       const matchingFriends = createDexieArrayQueryWithSource(() => {
         return db.friends.where({ age: param() }).toArray();
       }, param);

--- a/src/solid-dexie.test.ts
+++ b/src/solid-dexie.test.ts
@@ -172,13 +172,13 @@ describe("createDexieArrayQuery", () => {
     const PARAM = 30;
 
     await createRoot(async () => {
-      const [param, setParam] = createSignal(35);
-      const matchingFriends = createDexieArrayQueryWithSource((param) => {
-        return db.friends.where({ age: param }).toArray();
-      }, param);
+      const [filter, setFilter] = createSignal(35);
+      const matchingFriends = createDexieArrayQueryWithSource((x) => {
+        return db.friends.where({ age: x }).toArray();
+      }, filter);
 
       createRenderEffect(() => {
-        setParam(PARAM);
+        setFilter(PARAM);
       });
 
       createEffect(

--- a/src/solid-dexie.test.ts
+++ b/src/solid-dexie.test.ts
@@ -139,7 +139,7 @@ describe("createDexieArrayQuery", () => {
 
     await createRoot(async () => {
       const matchingFriends = createDexieArrayQueryWithSource((source) => {
-        return db.friends.where({ age: source() }).toArray();
+        return db.friends.where({ age: source }).toArray();
       }, PARAM);
 
       createEffect(
@@ -173,8 +173,8 @@ describe("createDexieArrayQuery", () => {
 
     await createRoot(async () => {
       const [param, setParam] = createSignal(35);
-      const matchingFriends = createDexieArrayQueryWithSource(() => {
-        return db.friends.where({ age: param() }).toArray();
+      const matchingFriends = createDexieArrayQueryWithSource((param) => {
+        return db.friends.where({ age: param }).toArray();
       }, param);
 
       createRenderEffect(() => {

--- a/src/solid-dexie.test.ts
+++ b/src/solid-dexie.test.ts
@@ -166,7 +166,7 @@ describe("createDexieArrayQuery", () => {
     expect(friends!).toMatchObject([{ name: "Expected", age: PARAM }]);
   });
 
-  test("filtered live array (2), add one item", async () => {
+  test("filtered live array (2), add two items", async () => {
     let friends: Friend[];
 
     const [resolve, startup, runDb] = runner();
@@ -205,6 +205,16 @@ describe("createDexieArrayQuery", () => {
       await db.friends.add({ name: "Foo", age: 40 });
     });
     expect(friends!).toMatchObject([{ name: "Expected", age: PARAM }]);
+
+    await runDb(async () => {
+      await db.friends.add({ name: "Expected2", age: PARAM });
+      await db.friends.add({ name: "Foo", age: 35 });
+      await db.friends.add({ name: "Thirty-seven", age: 37 });
+    });
+    expect(friends!).toMatchObject([
+      { name: "Expected", age: PARAM },
+      { name: "Expected2", age: PARAM }
+    ]);
   });
 
   test("live array, add two", async () => {

--- a/src/solid-dexie.ts
+++ b/src/solid-dexie.ts
@@ -46,7 +46,7 @@ export function createDexieArrayQueryWithSource<T, S>(
   const [store, setStore] = createStore<T[]>([]);
 
   let deps;
-  let sourceAccessor: Accessor<S> | undefined;
+  let sourceAccessor: Accessor<S | false | null | undefined> | undefined;
 
   const queryWithSource = () => {
     return querier(sourceAccessor)
@@ -56,7 +56,7 @@ export function createDexieArrayQueryWithSource<T, S>(
     sourceAccessor = source as Accessor<S>
     deps = [queryWithSource, source as Accessor<S>];
   } else {
-    sourceAccessor = (() => source) as Accessor<S>
+    sourceAccessor = () => source
     deps = [queryWithSource, sourceAccessor];
   }
 

--- a/src/solid-dexie.ts
+++ b/src/solid-dexie.ts
@@ -52,13 +52,8 @@ export function createDexieArrayQueryWithSource<T, S>(
     return querier(sourceAccessor?.())
   }
 
-  if (typeof source === "function") {
-    sourceAccessor = source as Accessor<S>
-    deps = [queryWithSource, source as Accessor<S>];
-  } else {
-    sourceAccessor = () => source
-    deps = [queryWithSource, sourceAccessor];
-  }
+  sourceAccessor = typeof source === "function" ? source as Accessor<S> : () => source;
+  deps = [queryWithSource, sourceAccessor];
 
   createEffect(
     on(deps, () => {

--- a/src/solid-dexie.ts
+++ b/src/solid-dexie.ts
@@ -6,10 +6,10 @@ import {
   on,
   onCleanup,
 } from "solid-js";
-import { createStore, reconcile, SetStoreFunction } from "solid-js/store";
+import { createStore, reconcile, ReconcileOptions, SetStoreFunction } from "solid-js/store";
 import { liveQuery, PromiseExtended } from "dexie";
 
-type ReconcileOptions = Parameters<typeof reconcile>[1];
+export const DEFAULT_RECONCILE_OPTIONS: ReconcileOptions = { key: "id" }
 
 type NotArray<T> = T extends any[] ? never : T;
 
@@ -42,7 +42,7 @@ function fromReconcileStore<T>(
   },
   store: T,
   setStore: SetStoreFunction<T>,
-  options: ReconcileOptions = { key: "id" }
+  options: ReconcileOptions = DEFAULT_RECONCILE_OPTIONS
 ): T {
   const unsub = producer.subscribe((v) => setStore(reconcile(v, options)));
   onCleanup(() => ("unsubscribe" in unsub ? unsub.unsubscribe() : unsub()));

--- a/src/solid-dexie.ts
+++ b/src/solid-dexie.ts
@@ -7,7 +7,7 @@ import {
 } from "solid-js";
 import { createStore, reconcile } from "solid-js/store";
 import { liveQuery, PromiseExtended } from "dexie";
-import {ResourceSource} from 'solid-js/types/reactive/signal';
+import { ResourceSource } from "solid-js/types/reactive/signal";
 
 import { fromReconcileStore, DEFAULT_RECONCILE_OPTIONS } from "./from-reconcile-store";
 
@@ -22,38 +22,29 @@ export function createDexieSignalQuery<T>(
   return () => get()();
 }
 
-
-export function createDexieArrayQuery<T>(
-  querier: () => T[] | Promise<T[]>,
-  options: ReconcileOptions = DEFAULT_RECONCILE_OPTIONS
-): T[] {
-  const [store, setStore] = createStore<T[]>([]);
-
-  createEffect(
-    on(querier, () => {
-      fromReconcileStore<T[]>(liveQuery(querier), store, setStore, options);
-    })
-  );
-
-  return store;
-}
-
-export function createDexieArrayQueryWithSource<T, S>(
+export function createDexieArrayQuery<T, S = undefined>(
   querier: (sourceValue?: S | false | null | undefined) => T[] | Promise<T[]>,
-  source: ResourceSource<S> = undefined,
-  options: ReconcileOptions = DEFAULT_RECONCILE_OPTIONS
+  options?: ReconcileOptions & {
+    source?: ResourceSource<S>,
+  },
+): T[]
+export function createDexieArrayQuery<T, S = undefined>(
+  querier: (_?: any) => T[] | Promise<T[]>,
+  options: ReconcileOptions & {
+    source?: never,
+  } = DEFAULT_RECONCILE_OPTIONS,
 ): T[] {
   const [store, setStore] = createStore<T[]>([]);
 
-  let deps;
   let sourceAccessor: Accessor<S | false | null | undefined> | undefined;
 
   const queryWithSource = () => {
-    return querier(sourceAccessor?.())
-  }
+    return querier(sourceAccessor?.());
+  };
 
+  let { source } = options;
   sourceAccessor = typeof source === "function" ? source as Accessor<S> : () => source;
-  deps = [queryWithSource, sourceAccessor];
+  const deps = [queryWithSource, sourceAccessor];
 
   createEffect(
     on(deps, () => {

--- a/src/solid-dexie.ts
+++ b/src/solid-dexie.ts
@@ -56,7 +56,8 @@ export function createDexieArrayQueryWithSource<T, S>(
     sourceAccessor = source as Accessor<S>
     deps = [queryWithSource, source as Accessor<S>];
   } else {
-    deps = [queryWithSource, (() => source) as Accessor<S>];
+    sourceAccessor = (() => source) as Accessor<S>
+    deps = [queryWithSource, sourceAccessor];
   }
 
   createEffect(

--- a/src/solid-dexie.ts
+++ b/src/solid-dexie.ts
@@ -4,12 +4,10 @@ import {
   createMemo,
   createEffect,
   on,
-  onCleanup,
 } from "solid-js";
-import { createStore, reconcile, ReconcileOptions, SetStoreFunction } from "solid-js/store";
+import { createStore } from "solid-js/store";
 import { liveQuery, PromiseExtended } from "dexie";
-
-export const DEFAULT_RECONCILE_OPTIONS: ReconcileOptions = { key: "id" }
+import { fromReconcileStore } from "./from-reconcile-store";
 
 type NotArray<T> = T extends any[] ? never : T;
 
@@ -31,20 +29,5 @@ export function createDexieArrayQuery<T>(
     })
   );
 
-  return store;
-}
-
-function fromReconcileStore<T>(
-  producer: {
-    subscribe: (
-      fn: (v: T) => void
-    ) => (() => void) | { unsubscribe: () => void };
-  },
-  store: T,
-  setStore: SetStoreFunction<T>,
-  options: ReconcileOptions = DEFAULT_RECONCILE_OPTIONS
-): T {
-  const unsub = producer.subscribe((v) => setStore(reconcile(v, options)));
-  onCleanup(() => ("unsubscribe" in unsub ? unsub.unsubscribe() : unsub()));
   return store;
 }

--- a/src/solid-dexie.ts
+++ b/src/solid-dexie.ts
@@ -5,9 +5,13 @@ import {
   createEffect,
   on,
 } from "solid-js";
-import { createStore } from "solid-js/store";
+import { createStore, reconcile } from "solid-js/store";
 import { liveQuery, PromiseExtended } from "dexie";
-import { fromReconcileStore } from "./from-reconcile-store";
+import {ResourceSource} from 'solid-js/types/reactive/signal';
+
+import { fromReconcileStore, DEFAULT_RECONCILE_OPTIONS } from "./from-reconcile-store";
+
+type ReconcileOptions = Parameters<typeof reconcile>[1];
 
 type NotArray<T> = T extends any[] ? never : T;
 
@@ -18,14 +22,46 @@ export function createDexieSignalQuery<T>(
   return () => get()();
 }
 
+
 export function createDexieArrayQuery<T>(
-  querier: () => T[] | Promise<T[]>
+  querier: () => T[] | Promise<T[]>,
+  options: ReconcileOptions = DEFAULT_RECONCILE_OPTIONS
 ): T[] {
   const [store, setStore] = createStore<T[]>([]);
 
   createEffect(
     on(querier, () => {
-      fromReconcileStore<T[]>(liveQuery(querier), store, setStore);
+      fromReconcileStore<T[]>(liveQuery(querier), store, setStore, options);
+    })
+  );
+
+  return store;
+}
+
+export function createDexieArrayQueryWithSource<T, S>(
+  querier: (source?: ResourceSource<S>) => T[] | Promise<T[]>,
+  source: ResourceSource<S> = undefined,
+  options: ReconcileOptions = DEFAULT_RECONCILE_OPTIONS
+): T[] {
+  const [store, setStore] = createStore<T[]>([]);
+
+  let deps;
+  let sourceAccessor: Accessor<S> | undefined;
+
+  const queryWithSource = () => {
+    return querier(sourceAccessor)
+  }
+
+  if (typeof source === "function") {
+    sourceAccessor = source as Accessor<S>
+    deps = [queryWithSource, source as Accessor<S>];
+  } else {
+    deps = [queryWithSource, (() => source) as Accessor<S>];
+  }
+
+  createEffect(
+    on(deps, () => {
+      fromReconcileStore<T[]>(liveQuery(queryWithSource), store, setStore, options ?? undefined);
     })
   );
 

--- a/src/solid-dexie.ts
+++ b/src/solid-dexie.ts
@@ -39,7 +39,7 @@ export function createDexieArrayQuery<T>(
 }
 
 export function createDexieArrayQueryWithSource<T, S>(
-  querier: (source?: ResourceSource<S>) => T[] | Promise<T[]>,
+  querier: (sourceValue?: S | false | null | undefined) => T[] | Promise<T[]>,
   source: ResourceSource<S> = undefined,
   options: ReconcileOptions = DEFAULT_RECONCILE_OPTIONS
 ): T[] {
@@ -49,7 +49,7 @@ export function createDexieArrayQueryWithSource<T, S>(
   let sourceAccessor: Accessor<S | false | null | undefined> | undefined;
 
   const queryWithSource = () => {
-    return querier(sourceAccessor)
+    return querier(sourceAccessor?.())
   }
 
   if (typeof source === "function") {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,10 @@
     "esModuleInterop": true,
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "types": ["vite/client"],
+    "types": [
+      "vite/client",
+      "jest"
+    ],
     "isolatedModules": true
   }
 }


### PR DESCRIPTION
Thanks for `solid-dexie`, it's a super useful library!

----

This adds a way to parametrize `createDexieArrayQuery` (in a way that is reactive when the parameter changes). This has allowed me to use `createDexieArrayQuery` similarly to [`createResource`](https://www.solidjs.com/docs/latest/api#createresource) taking a `source` function (such as a signal).

The way I've used this is for a paginated query, where the page number is a signal. But it could be any signal, so I think it's pretty generic.

### The tests are currently passing, but I should probably add more

This changeset could surely be improved. I don't think I've added adequate tests for example. I might also want to add a test demonstrating a pagination use-case.

----

### Caveat!

This change **might be unnecessary,** I'm not sure at this moment.

The test cases I've added currently _don't_ demonstrate a scenario where the change actually matters...! Sorry about that... I am not sure how to represent it in a test yet. One of the ways I could improve the testing is by implementing one of those scenarios. (I've tried a few things but no dice yet.)

I'm _pretty_ sure a change like this helps some scenario(s) though; apologies that I don't have a reproduction of that yet!