### PR TITLE
fix: add missing paren in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can also create dynamic queries with signals:
 
 ```typescript
 const [value, setValue] = createSignal(0);
-const friends = createDexieArrayQuery() => db.friends.where("age").above(value()).toArray());
+const friends = createDexieArrayQuery(() => db.friends.where("age").above(value()).toArray());
 ```
 
 Now when you modify `value` with `setValue`, `friends` automatically updates to


### PR DESCRIPTION
Hello,

Thank you for the great library, I expect to be using it in any project that uses both SolidJS and IndexedDB 🙌 

I'd love to contribute more in the future, but for now I just noticed one tiny thing, a missing parenthesis in the readme.