### PR TITLE
Add ability to use reconcile options

### DIFF
--- a/src/solid-dexie.ts
+++ b/src/solid-dexie.ts
@@ -21,13 +21,14 @@ export function createDexieSignalQuery<T>(
 }
 
 export function createDexieArrayQuery<T>(
-  querier: () => T[] | Promise<T[]>
+  querier: () => T[] | Promise<T[]>,
+  options?: ReconcileOptions,
 ): T[] {
   const [store, setStore] = createStore<T[]>([]);
 
   createEffect(
     on(querier, () => {
-      fromReconcileStore<T[]>(liveQuery(querier), store, setStore);
+      fromReconcileStore<T[]>(liveQuery(querier), store, setStore, options);
     })
   );
 


### PR DESCRIPTION
This is an important detail for dealing with arrays of objects whose unique keys are not "id".

Example:
createDexieArrayQuery(() => {}, { key: "email" })